### PR TITLE
Fix for null parent in predraw

### DIFF
--- a/lib/src/main/java/com/nhaarman/supertooltips/ToolTipView.java
+++ b/lib/src/main/java/com/nhaarman/supertooltips/ToolTipView.java
@@ -101,7 +101,9 @@ public class ToolTipView extends LinearLayout implements ViewTreeObserver.OnPreD
         RelativeLayout.LayoutParams layoutParams = (RelativeLayout.LayoutParams) getLayoutParams();
         layoutParams.width = mWidth;
         setLayoutParams(layoutParams);
-
+        if (getParent() == null) {
+            return false;
+        }
         if (mToolTip != null) {
             applyToolTipPosition(true);
         }


### PR DESCRIPTION
Fix for https://kikinteractive.atlassian.net/browse/SHD-842
Fix taken from: https://github.com/nhaarman/supertooltips/pull/30/commits/a4af4a08c29dfa143c7c2322fd5fde07ca110a38.

There are 2 places a null parent can cause problems, onPreDraw (fixed with this PR) and in applyToolTipPosition, it looks like it is already handled in the second case (returns on null parent).